### PR TITLE
fix: register several artifacts at once

### DIFF
--- a/src/scripts/register_artifact.sh
+++ b/src/scripts/register_artifact.sh
@@ -1,27 +1,31 @@
 #!/bin/bash
 
-if [ -z "${ARTIFACT_TO_REGISTER}" ]; then
-  DOCKER_ARTIFACT=$(awk '{for(i=1; i<=NF; i++) printf "--artifact-path " $i " "}' < "${BUILT_DOCKER_IMAGES_FILE}")
-else
-  DOCKER_ARTIFACT="--artifact-path ${ARTIFACT_TO_REGISTER}"
-fi
-
-if [ "${DEBUG}" == "1" ]; then
-  export
-  set -x
-
-  # shellcheck disable=SC2086
-  /tmp/billy health -v --aqua-key ${AQUA_KEY} --aqua-secret ${AQUA_SECRET} --access-token ${GITHUB_TOKEN} ${DOCKER_ARTIFACT}
-fi
-
-if [ -z "${DOCKER_ARTIFACT}" ]; then
-  echo "No artifact to register."
-else
-  COMMAND="/tmp/billy generate -v --aqua-key ${AQUA_KEY} --aqua-secret ${AQUA_SECRET} --access-token ${GITHUB_TOKEN} ${DOCKER_ARTIFACT}"
-
-  if [ "${DRY_RUN}" == "1" ]; then
-    echo "DRY_RUN: Running command: ${COMMAND}"
+RegisterArtifact() {
+  if [ -z "$1" ]; then
+    echo "No artifact to register."
   else
-    eval "${COMMAND}"
+    if [ "${DEBUG}" == "1" ]; then
+      export
+      set -x
+
+      # shellcheck disable=SC2086
+      /tmp/billy health -v --aqua-key ${AQUA_KEY} --aqua-secret ${AQUA_SECRET} --access-token ${GITHUB_TOKEN} --artifact-path $1
+    fi
+
+    COMMAND="/tmp/billy generate -v --aqua-key ${AQUA_KEY} --aqua-secret ${AQUA_SECRET} --access-token ${GITHUB_TOKEN} --artifact-path $1"
+    if [ "${DRY_RUN}" == "1" ]; then
+      echo "DRY_RUN: Running command: ${COMMAND}"
+    else
+      eval "${COMMAND}"
+    fi
   fi
+}
+
+if [ -z "${ARTIFACT_TO_REGISTER}" ]; then
+  while IFS="" read -r line || [ -n "$line" ]
+  do
+    RegisterArtifact "${line}"
+  done < "${BUILT_DOCKER_IMAGES_FILE}"
+else
+  RegisterArtifact "${ARTIFACT_TO_REGISTER}"
 fi


### PR DESCRIPTION
Billy's CLI does not handle registering more than one artifact. When we have a list of artifacts to register we need to run the command for each artifact.